### PR TITLE
Pydantic 2 Compatibility and Simulation Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For computing partially polarised charges, we can use the class ComputePartialPo
 
 ```python
 from openff.toolkit.topology import Molecule
-from naglbmis.models import ComputePartialPolarised
+from naglmbis.models import ComputePartialPolarised
 from naglmbis.models import load_charge_model
 
 gas_model = load_charge_model(charge_model="nagl-gas-charge-dipole-wb")
@@ -71,7 +71,7 @@ polarised_model = ComputePartialPolarised(
    alpha = 0.5 #scaling parameter which can be adjusted
 )
 
-polarised_model.compute_properties(ethanol.to_rdkit())
+polarised_model.compute_polarised_charges(ethanol.to_rdkit())
 ```
 
 

--- a/devtools/conda-envs/env.yaml
+++ b/devtools/conda-envs/env.yaml
@@ -31,7 +31,7 @@ dependencies:
   # - qcportal
   # - qubekit
   - openff-utilities
-  - pydantic <2
+  - pydantic
   - polars
   - pip:
       - git+https://github.com/bismuthadams1/nagl.git

--- a/naglmbis/features/atom.py
+++ b/naglmbis/features/atom.py
@@ -2,7 +2,10 @@ from typing import Literal
 
 import torch
 from nagl.features import AtomFeature, one_hot_encode, register_atom_feature
-from pydantic import Extra, Field, dataclasses
+try:
+    from pydantic.v1 import Extra, Field, dataclasses
+except ImportError:
+    from pydantic import Extra, Field, dataclasses
 from rdkit import Chem
 
 

--- a/scripts/train_charge_dipole_esp_model/train_model.py
+++ b/scripts/train_charge_dipole_esp_model/train_model.py
@@ -21,7 +21,10 @@ from nagl.training import DGLMoleculeDataModule, DGLMoleculeLightningModel
 import typing
 import logging
 import pathlib
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except ImportError:
+    import pydantic
 from rdkit import Chem
 import dataclasses
 

--- a/scripts/train_charge_dipole_model/train_model.py
+++ b/scripts/train_charge_dipole_model/train_model.py
@@ -21,7 +21,10 @@ from nagl.training import DGLMoleculeDataModule, DGLMoleculeLightningModel
 import typing
 import logging
 import pathlib
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except ImportError:
+    import pydantic
 from rdkit import Chem
 import dataclasses
 

--- a/scripts/train_charge_model/train_model.py
+++ b/scripts/train_charge_model/train_model.py
@@ -21,7 +21,10 @@ from nagl.training import DGLMoleculeDataModule, DGLMoleculeLightningModel
 import typing
 import logging
 import pathlib
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except ImportError:
+    import pydantic
 from rdkit import Chem
 import dataclasses
 


### PR DESCRIPTION
As described [here](https://github.com/bismuthadams1/nagl/pull/4) I had some pain installing things due to the requirement for `pydantic<1`, so I've updated this and your `nagl` fork to be compatible with `pydantic` 1 or 2.

I've also updated the README with an example of how to get the charges into a simulation/ made sure the examples run.

Once the PR at https://github.com/bismuthadams1/nagl is merged, the install should work - I've checked that all tests pass.

Let me know if you want me to change anything!

Thanks.